### PR TITLE
Use a simple parser for stanzas

### DIFF
--- a/.chloggen/fix-stanza-parsing.yaml
+++ b/.chloggen/fix-stanza-parsing.yaml
@@ -1,8 +1,8 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. crosslink)
-component:
+component: tabuilder
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix handling of Splunk stanzas

--- a/.chloggen/fix-stanza-parsing.yaml
+++ b/.chloggen/fix-stanza-parsing.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix handling of Splunk stanzas
+
+# One or more tracking issues related to the change
+issues: [108]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Splunk stanzas are not URL so using `url.Parse` fails for many valid Splunk stanzas.
+  Switch usage of `url.Parse` to a small local parser that basically just separates
+  the stanzas into two parts as needed.

--- a/internal/receiver/tcpreceiver/config.go
+++ b/internal/receiver/tcpreceiver/config.go
@@ -4,9 +4,8 @@
 package tcpreceiver
 
 import (
-	"net/url"
-
 	"github.com/splunk/tarunner/internal/conf"
+	"github.com/splunk/tarunner/internal/stanza"
 )
 
 type Config struct {
@@ -18,6 +17,6 @@ type Config struct {
 }
 
 func (cfg *Config) Validate() error {
-	_, err := url.Parse(cfg.Input.Configuration.Stanza.Name)
+	_, err := stanza.ParseName(cfg.Input.Configuration.Stanza.Name)
 	return err
 }

--- a/internal/receiver/tcpreceiver/receiver.go
+++ b/internal/receiver/tcpreceiver/receiver.go
@@ -4,8 +4,6 @@
 package tcpreceiver
 
 import (
-	"net/url"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/tcp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/move"
 
@@ -14,6 +12,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/noop"
 
 	"github.com/splunk/tarunner/internal/operator/prop"
+	"github.com/splunk/tarunner/internal/stanza"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -62,8 +61,8 @@ func (monitor) BaseConfig(cfg component.Config) adapter.BaseConfig {
 func (t monitor) InputConfig(config component.Config) operator.Config {
 	rcfg := config.(Config)
 	oc := tcp.NewConfig()
-	listenAddress, _ := url.Parse(rcfg.Input.Configuration.Stanza.Name)
-	oc.ListenAddress = listenAddress.Host
+	listenAddress, _ := stanza.ParseName(rcfg.Input.Configuration.Stanza.Name)
+	oc.ListenAddress = stanza.ListenAddress(listenAddress.Target)
 	oc.Attributes = map[string]helper.ExprStringConfig{}
 	if hostParam := rcfg.Input.Configuration.Stanza.Params.Get("host"); hostParam != nil {
 		// TODO: find a way to run host detection when requested.

--- a/internal/receiver/udpreceiver/config.go
+++ b/internal/receiver/udpreceiver/config.go
@@ -4,9 +4,8 @@
 package udpreceiver
 
 import (
-	"net/url"
-
 	"github.com/splunk/tarunner/internal/conf"
+	"github.com/splunk/tarunner/internal/stanza"
 )
 
 type Config struct {
@@ -18,6 +17,6 @@ type Config struct {
 }
 
 func (cfg *Config) Validate() error {
-	_, err := url.Parse(cfg.Input.Configuration.Stanza.Name)
+	_, err := stanza.ParseName(cfg.Input.Configuration.Stanza.Name)
 	return err
 }

--- a/internal/receiver/udpreceiver/receiver.go
+++ b/internal/receiver/udpreceiver/receiver.go
@@ -4,8 +4,6 @@
 package udpreceiver
 
 import (
-	"net/url"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/udp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/move"
 
@@ -14,6 +12,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/noop"
 
 	"github.com/splunk/tarunner/internal/operator/prop"
+	"github.com/splunk/tarunner/internal/stanza"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -62,8 +61,8 @@ func (monitor) BaseConfig(cfg component.Config) adapter.BaseConfig {
 func (t monitor) InputConfig(config component.Config) operator.Config {
 	rcfg := config.(Config)
 	oc := udp.NewConfig()
-	listenAddress, _ := url.Parse(rcfg.Input.Configuration.Stanza.Name)
-	oc.ListenAddress = listenAddress.Host
+	listenAddress, _ := stanza.ParseName(rcfg.Input.Configuration.Stanza.Name)
+	oc.ListenAddress = stanza.ListenAddress(listenAddress.Target)
 	oc.Attributes = map[string]helper.ExprStringConfig{}
 	if hostParam := rcfg.Input.Configuration.Stanza.Params.Get("host"); hostParam != nil {
 		// TODO: find a way to run host detection when requested.

--- a/internal/receiver/wineventlogreceiver/receiver.go
+++ b/internal/receiver/wineventlogreceiver/receiver.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/splunk/tarunner/internal/operator/prop"
+	"github.com/splunk/tarunner/internal/stanza"
 )
 
 type welreceiver struct{}
@@ -68,7 +69,8 @@ func createSetSourceOperator() operator.Config {
 func (t welreceiver) InputConfig(config component.Config) operator.Config {
 	rcfg := config.(Config)
 	oc := windows.NewConfig()
-	oc.Channel = rcfg.Input.Configuration.Stanza.Name
+	parsed, _ := stanza.ParseName(rcfg.Input.Configuration.Stanza.Name)
+	oc.Channel = parsed.Target
 	oc.Attributes = map[string]helper.ExprStringConfig{}
 	if hostParam := rcfg.Input.Configuration.Stanza.Params.Get("host"); hostParam != nil {
 		// TODO: find a way to run host detection when requested.

--- a/internal/script/command.go
+++ b/internal/script/command.go
@@ -5,32 +5,28 @@ package script
 
 import (
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/splunk/tarunner/internal/conf"
+	"github.com/splunk/tarunner/internal/stanza"
 )
 
 func DetermineCommandName(baseDir string, input conf.Input) (string, error) {
-	if after, ok := strings.CutPrefix(input.Configuration.Stanza.Name, "monitor://"); ok {
-		return after, nil
-	}
-	if after, ok := strings.CutPrefix(input.Configuration.Stanza.Name, "batch://"); ok {
-		return after, nil
-	}
-	parsed, err := url.Parse(input.Configuration.Stanza.Name)
+	parsed, err := stanza.ParseName(input.Configuration.Stanza.Name)
 	if err != nil {
 		return "", err
 	}
-	switch parsed.Scheme {
+	switch parsed.Kind {
+	case "monitor", "batch":
+		return parsed.Target, nil
 	case "script":
-		return GetPath(baseDir, filepath.Join(parsed.Host, parsed.Path))
+		return GetPath(baseDir, parsed.Target)
 	case "":
-		return GetPath(baseDir, filepath.Join("bin", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH), input.Configuration.Stanza.Name))
+		return GetPath(baseDir, filepath.Join("bin", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH), parsed.Target))
 	default:
-		return "", fmt.Errorf("unknown scheme %q", parsed.Scheme)
+		return "", fmt.Errorf("unknown scheme %q", parsed.Kind)
 	}
 }
 

--- a/internal/scriptedinput/input.go
+++ b/internal/scriptedinput/input.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
 	"os/exec"
 	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/splunk/tarunner/internal/script"
+	"github.com/splunk/tarunner/internal/stanza"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -48,17 +48,17 @@ func (si *ScriptedInput) Stop() error {
 }
 
 func (si *ScriptedInput) scheduleInput(baseDir string, input conf.Input) (bool, error) {
-	parsed, err := url.Parse(input.Configuration.Stanza.Name)
+	parsed, err := stanza.ParseName(input.Configuration.Stanza.Name)
 	if err != nil {
 		return false, err
 	}
-	switch parsed.Scheme {
+	switch parsed.Kind {
 	case "script":
 		return si.scheduleScriptedInput(baseDir, input)
 	case "":
 		return si.scheduleScriptedInput(baseDir, input)
 	default:
-		return false, fmt.Errorf("unknown scheme %q", parsed.Scheme)
+		return false, fmt.Errorf("unknown scheme %q", parsed.Kind)
 	}
 }
 

--- a/internal/stanza/name.go
+++ b/internal/stanza/name.go
@@ -1,0 +1,50 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stanza contains helpers for Splunk stanza names.
+package stanza
+
+import (
+	"errors"
+	"strings"
+)
+
+var errEmptyKind = errors.New("empty stanza kind")
+
+// Name is the type and target encoded in a Splunk input stanza name.
+// Target is intentionally kept opaque because its syntax depends on Kind.
+type Name struct {
+	Kind   string
+	Target string
+}
+
+// ParseName splits a Splunk stanza name without applying URL semantics.
+//
+// Splunk uses the form kind://target for many inputs, but the target can be a
+// path, an event log channel, or a network-specific value. Unprefixed names
+// are returned with an empty Kind and are used by scripted inputs.
+func ParseName(raw string) (Name, error) {
+	if kind, target, ok := strings.Cut(raw, "://"); ok {
+		if kind == "" {
+			return Name{}, errEmptyKind
+		}
+		return Name{Kind: strings.ToLower(kind), Target: target}, nil
+	}
+
+	for _, kind := range []string{"tcp", "udp"} {
+		if strings.HasPrefix(strings.ToLower(raw), kind+":") {
+			return Name{Kind: kind, Target: raw[len(kind)+1:]}, nil
+		}
+	}
+
+	return Name{Target: raw}, nil
+}
+
+// ListenAddress converts Splunk's port-only network stanza form to the
+// host:port form expected by the OpenTelemetry network receivers.
+func ListenAddress(target string) string {
+	if target != "" && !strings.Contains(target, ":") {
+		return ":" + target
+	}
+	return target
+}

--- a/internal/stanza/name_test.go
+++ b/internal/stanza/name_test.go
@@ -1,0 +1,44 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package stanza
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseName(t *testing.T) {
+	tests := []struct {
+		name   string
+		parsed Name
+	}{
+		{name: "WinEventLog://DFS some name", parsed: Name{Kind: "wineventlog", Target: "DFS some name"}},
+		{name: "monitor:///var/log/splunk/*.log", parsed: Name{Kind: "monitor", Target: "/var/log/splunk/*.log"}},
+		{name: `monitor://C:\Program Files\Splunk\splunkd.log`, parsed: Name{Kind: "monitor", Target: `C:\Program Files\Splunk\splunkd.log`}},
+		{name: "tcp://:9997", parsed: Name{Kind: "tcp", Target: ":9997"}},
+		{name: "UDP:514", parsed: Name{Kind: "udp", Target: "514"}},
+		{name: "my_script", parsed: Name{Target: "my_script"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, err := ParseName(test.name)
+			require.NoError(t, err)
+			require.Equal(t, test.parsed, parsed)
+		})
+	}
+}
+
+func TestParseNameRejectsEmptyKind(t *testing.T) {
+	_, err := ParseName("://target")
+	require.ErrorIs(t, err, errEmptyKind)
+}
+
+func TestListenAddress(t *testing.T) {
+	require.Equal(t, ":9997", ListenAddress("9997"))
+	require.Equal(t, ":9997", ListenAddress(":9997"))
+	require.Equal(t, "127.0.0.1:9997", ListenAddress("127.0.0.1:9997"))
+	require.Equal(t, "[::1]:9997", ListenAddress("[::1]:9997"))
+}

--- a/internal/tabuilder/tabuilder.go
+++ b/internal/tabuilder/tabuilder.go
@@ -78,7 +78,7 @@ func CreateReceiver(ctx context.Context, baseDir string, next consumer.Logs, inp
 			Transforms: transforms,
 			Props:      props,
 		}, next)
-	case "WinEventLog":
+	case "wineventlog":
 		f := wineventlogreceiver.NewFactory()
 		return f.CreateLogs(ctx, settings(f, parsed.Target, telemetrySettings), wineventlogreceiver.Config{
 			Input:      input,

--- a/internal/tabuilder/tabuilder.go
+++ b/internal/tabuilder/tabuilder.go
@@ -78,7 +78,7 @@ func CreateReceiver(ctx context.Context, baseDir string, next consumer.Logs, inp
 			Transforms: transforms,
 			Props:      props,
 		}, next)
-	case "wineventlog":
+	case "WinEventLog":
 		f := wineventlogreceiver.NewFactory()
 		return f.CreateLogs(ctx, settings(f, parsed.Target, telemetrySettings), wineventlogreceiver.Config{
 			Input:      input,

--- a/internal/tabuilder/tabuilder.go
+++ b/internal/tabuilder/tabuilder.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 
@@ -26,10 +25,11 @@ import (
 	"github.com/splunk/tarunner/internal/receiver/tcpreceiver"
 	"github.com/splunk/tarunner/internal/receiver/udpreceiver"
 	"github.com/splunk/tarunner/internal/receiver/wineventlogreceiver"
+	"github.com/splunk/tarunner/internal/stanza"
 )
 
 // CreateReceivers builds a logs receiver for every enabled input stanza,
-// dispatching by the stanza name's URL scheme. Stanzas with disabled=1 are
+// dispatching by the stanza name's input kind. Stanzas with disabled=1 are
 // skipped.
 func CreateReceivers(ctx context.Context, inputs []conf.Input, transforms []conf.Transform, props []conf.Prop, baseDir string, next consumer.Logs, telemetrySettings component.TelemetrySettings) ([]receiver.Logs, error) {
 	var receivers []receiver.Logs
@@ -49,14 +49,14 @@ func CreateReceivers(ctx context.Context, inputs []conf.Input, transforms []conf
 
 // CreateReceiver builds a single logs receiver for an input stanza.
 func CreateReceiver(ctx context.Context, baseDir string, next consumer.Logs, input conf.Input, transforms []conf.Transform, props []conf.Prop, telemetrySettings component.TelemetrySettings) (receiver.Logs, error) {
-	parsed, err := url.Parse(input.Configuration.Stanza.Name)
+	parsed, err := stanza.ParseName(input.Configuration.Stanza.Name)
 	if err != nil {
 		return nil, err
 	}
-	switch parsed.Scheme {
+	switch parsed.Kind {
 	case "script", "":
 		f := scriptreceiver.NewFactory()
-		return f.CreateLogs(ctx, settings(f, parsed.Path, telemetrySettings), &scriptreceiver.Config{
+		return f.CreateLogs(ctx, settings(f, parsed.Target, telemetrySettings), &scriptreceiver.Config{
 			Input:      input,
 			BaseDir:    baseDir,
 			Transforms: transforms,
@@ -64,7 +64,7 @@ func CreateReceiver(ctx context.Context, baseDir string, next consumer.Logs, inp
 		}, next)
 	case "batch":
 		f := batchreceiver.NewFactory()
-		return f.CreateLogs(ctx, settings(f, parsed.Path, telemetrySettings), &scriptreceiver.Config{
+		return f.CreateLogs(ctx, settings(f, parsed.Target, telemetrySettings), &scriptreceiver.Config{
 			Input:      input,
 			BaseDir:    baseDir,
 			Transforms: transforms,
@@ -72,15 +72,15 @@ func CreateReceiver(ctx context.Context, baseDir string, next consumer.Logs, inp
 		}, next)
 	case "monitor":
 		f := monitorreceiver.NewFactory()
-		return f.CreateLogs(ctx, settings(f, parsed.Path, telemetrySettings), monitorreceiver.Config{
+		return f.CreateLogs(ctx, settings(f, parsed.Target, telemetrySettings), monitorreceiver.Config{
 			Input:      input,
 			BaseDir:    baseDir,
 			Transforms: transforms,
 			Props:      props,
 		}, next)
-	case "WinEventLog":
+	case "wineventlog":
 		f := wineventlogreceiver.NewFactory()
-		return f.CreateLogs(ctx, settings(f, parsed.Path, telemetrySettings), wineventlogreceiver.Config{
+		return f.CreateLogs(ctx, settings(f, parsed.Target, telemetrySettings), wineventlogreceiver.Config{
 			Input:      input,
 			BaseDir:    baseDir,
 			Transforms: transforms,
@@ -88,7 +88,7 @@ func CreateReceiver(ctx context.Context, baseDir string, next consumer.Logs, inp
 		}, next)
 	case "tcp":
 		f := tcpreceiver.NewFactory()
-		return f.CreateLogs(ctx, settings(f, parsed.Path, telemetrySettings), tcpreceiver.Config{
+		return f.CreateLogs(ctx, settings(f, parsed.Target, telemetrySettings), tcpreceiver.Config{
 			Input:      input,
 			BaseDir:    baseDir,
 			Transforms: transforms,
@@ -96,14 +96,14 @@ func CreateReceiver(ctx context.Context, baseDir string, next consumer.Logs, inp
 		}, next)
 	case "udp":
 		f := udpreceiver.NewFactory()
-		return f.CreateLogs(ctx, settings(f, parsed.Path, telemetrySettings), udpreceiver.Config{
+		return f.CreateLogs(ctx, settings(f, parsed.Target, telemetrySettings), udpreceiver.Config{
 			Input:      input,
 			BaseDir:    baseDir,
 			Transforms: transforms,
 			Props:      props,
 		}, next)
 	default:
-		return nil, fmt.Errorf("unsupported scheme %q", parsed.Scheme)
+		return nil, fmt.Errorf("unsupported scheme %q", parsed.Kind)
 	}
 }
 


### PR DESCRIPTION
- Replaced use of `url.Parse` with a custom parser for Splunk stanza kinds and opaque targets
- Normalize kind matching and convert port-only network targets to listen addresses (I'm not sure this is a good idea, it seems better for the handler of the specific kind of stanza to handle that, but for now it is acceptable).
- Add unit coverage for stanza parsing and network address handling

Manually validated via https://github.com/signalfx/splunk-otel-collector/pull/7896 with the testing command:

```pwsh
.\run-example.ps1 -TaPackagePath C:\Users\pjanotti\Downloads\splunk-add-on-for-microsoft-windows_1100.spl `
  -SplunkHecUrl https://localhost:8088/services/collector/event `
  -SplunkHecToken '00000000-0000-0000-0000-0000000000000' `
  -DisabledStanzaNames powershell,MonitorNoHandle,WinEventLog,WinHostMon,WinPrintMon,WinNetMon,perfmon,WinRegMon,admon
```